### PR TITLE
Added eslintrc to packages/ui

### DIFF
--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    ...require('config/eslint-next.js'),
+    parserOptions: {
+      tsconfigRootDir: __dirname,
+      project: './tsconfig.json',
+    },
+  }
+  

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,9 +4,11 @@
   "main": "./index.tsx",
   "types": "./index.tsx",
   "license": "MIT",
-  "devDependencies": {
+  "dependencies": {
     "@types/react": "^17.0.37",
-    "@types/react-dom": "^17.0.11",
+    "@types/react-dom": "^17.0.11"
+  },
+  "devDependencies": {
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.5",
     "tailwindcss": "^3.0.7",


### PR DESCRIPTION
Running `yarn build` with staged files in `packages/ui` resulted in an error because of a missing `.eslintrc.js` file in `packages/ui`. 

This PR fixes that and get rids of a ~~warning~~ error where `@types/react` should be in `dependencies` instead of `devDependencies`.